### PR TITLE
Add aidw scope command

### DIFF
--- a/src/aidw/cli.py
+++ b/src/aidw/cli.py
@@ -273,6 +273,26 @@ def status(session_id: str) -> None:
 
 
 @cli.command()
+@click.argument("context", required=False, default="")
+def scope(context: str) -> None:
+    """Run autonomous scoping workflow.
+
+    Finds unscoped Notion tasks, analyzes relevant GitHub repos,
+    and posts scoping comments.
+
+    Optionally provide CONTEXT to guide the scoping focus.
+
+    \b
+    Examples:
+      aidw scope
+      aidw scope "Focus on authentication-related tasks"
+    """
+    from aidw.commands.scope import scope_command
+
+    asyncio.run(scope_command.execute(context))
+
+
+@cli.command()
 @click.option("--follow", "-f", is_flag=True, help="Follow log output")
 @click.option("--lines", "-n", default=50, help="Number of lines to show")
 def logs(follow: bool, lines: int) -> None:

--- a/src/aidw/commands/__init__.py
+++ b/src/aidw/commands/__init__.py
@@ -1,10 +1,11 @@
-"""AIDW Commands - The 5 workflow entry points."""
+"""AIDW Commands - Workflow entry points."""
 
 from aidw.commands.plan import plan_command
 from aidw.commands.refine import refine_command
 from aidw.commands.build import build_command
 from aidw.commands.oneshot import oneshot_command
 from aidw.commands.iterate import iterate_command
+from aidw.commands.scope import scope_command
 
 __all__ = [
     "plan_command",
@@ -12,4 +13,5 @@ __all__ = [
     "build_command",
     "oneshot_command",
     "iterate_command",
+    "scope_command",
 ]

--- a/src/aidw/commands/scope.py
+++ b/src/aidw/commands/scope.py
@@ -1,0 +1,199 @@
+"""aidw scope command - Autonomous scoping workflow."""
+
+import logging
+from pathlib import Path
+
+import click
+from e2b_code_interpreter import Sandbox
+
+from aidw.env import get_settings
+
+logger = logging.getLogger(__name__)
+
+# Sandbox timeout in seconds (1 hour)
+SANDBOX_TIMEOUT = 3600
+
+# Claude Code command timeout (30 minutes)
+CLAUDE_TIMEOUT = 1800
+
+
+class ScopeCommand:
+    """Autonomous scoping workflow."""
+
+    command_name = "scope"
+    prompt_template = "scope.md"
+
+    def _load_prompt(self, context: str = "") -> str:
+        """Load and render the prompt template."""
+        prompt_path = Path(__file__).parent.parent / "prompts" / self.prompt_template
+        prompt = prompt_path.read_text()
+
+        if context:
+            prompt = f"{prompt}\n\n## Additional Context\n\n{context}"
+
+        return prompt
+
+    async def execute(self, context: str = "") -> dict:
+        """Run autonomous scoping.
+
+        Args:
+            context: Optional context to guide the scoping focus
+
+        Returns:
+            dict with summary of what was scoped
+        """
+        settings = get_settings()
+
+        click.echo("Creating sandbox...")
+        sandbox = Sandbox.create(api_key=settings.e2b_api_key, timeout=SANDBOX_TIMEOUT)
+
+        try:
+            # Install aitk for Notion access
+            click.echo("Installing tools...")
+            await self._install_tools(sandbox)
+
+            # Sync aitk config for env store support
+            await self._sync_aitk_config(sandbox)
+
+            # Sync Claude auth
+            await self._sync_claude_auth(sandbox)
+
+            # Configure GitHub CLI
+            await self._setup_github_auth(sandbox, settings.gh_token)
+
+            # Install Claude Code
+            click.echo("Installing Claude Code...")
+            result = sandbox.commands.run(
+                "sudo npm install -g @anthropic-ai/claude-code",
+                timeout=300,
+            )
+            if result.exit_code != 0:
+                raise RuntimeError(f"Failed to install Claude Code: {result.stderr}")
+
+            # Load and render prompt
+            prompt = self._load_prompt(context)
+
+            # Write prompt to file to avoid shell escaping issues
+            prompt_file = "/tmp/claude_prompt.txt"
+            sandbox.files.write(prompt_file, prompt)
+
+            # Build command with auth
+            env_vars = []
+            if settings.claude_token:
+                env_vars.append(f"CLAUDE_CODE_OAUTH_TOKEN={settings.claude_token}")
+            if settings.gh_token:
+                env_vars.append(f"GH_TOKEN={settings.gh_token}")
+
+            env_prefix = " ".join(env_vars) + " " if env_vars else ""
+            command = f'{env_prefix}claude -p "$(cat {prompt_file})" --output-format json --dangerously-skip-permissions'
+
+            click.echo("Running autonomous scoping workflow...")
+            click.echo("(This may take several minutes)")
+
+            # Run Claude Code
+            result = sandbox.commands.run(command, timeout=CLAUDE_TIMEOUT)
+
+            if result.exit_code != 0:
+                click.secho(f"Scoping failed: {result.stderr or result.stdout}", fg="red")
+                return {"success": False, "error": result.stderr or result.stdout}
+
+            click.secho("Scoping completed successfully!", fg="green")
+            click.echo(result.stdout)
+
+            return {"success": True, "output": result.stdout}
+
+        finally:
+            click.echo("Cleaning up sandbox...")
+            sandbox.kill()
+
+    async def _install_tools(self, sandbox: Sandbox) -> None:
+        """Install development tools in the sandbox."""
+        # Check if uv is available (preferred), otherwise fall back to pip
+        try:
+            uv_check = sandbox.commands.run("which uv", timeout=10)
+            use_uv = uv_check.exit_code == 0
+        except Exception:
+            use_uv = False
+
+        if use_uv:
+            result = sandbox.commands.run(
+                "uv tool install git+https://github.com/Mandalorian007/aitk",
+                timeout=120,
+            )
+        else:
+            result = sandbox.commands.run(
+                "pip install git+https://github.com/Mandalorian007/aitk",
+                timeout=120,
+            )
+
+        if result.exit_code != 0:
+            logger.warning(f"Failed to install aitk: {result.stderr}")
+        else:
+            logger.info(f"aitk installed successfully via {'uv' if use_uv else 'pip'}")
+
+    async def _sync_aitk_config(self, sandbox: Sandbox) -> None:
+        """Sync aitk configuration to sandbox for env store access."""
+        aitk_config = Path.home() / ".config/aitk/config"
+        if not aitk_config.exists():
+            logger.debug("No aitk config found, skipping env store setup")
+            return
+
+        try:
+            content = aitk_config.read_text()
+            sandbox.commands.run("mkdir -p /home/user/.config/aitk")
+            sandbox.files.write("/home/user/.config/aitk/config", content)
+            sandbox.commands.run("chmod 600 /home/user/.config/aitk/config")
+            logger.info("aitk config synced to sandbox")
+        except Exception as e:
+            logger.warning(f"Failed to sync aitk config: {e}")
+
+    async def _sync_claude_auth(self, sandbox: Sandbox) -> None:
+        """Sync Claude authentication to sandbox."""
+        claude_dir = Path.home() / ".claude"
+        if not claude_dir.exists():
+            logger.warning("No Claude auth directory found, skipping auth sync")
+            return
+
+        sandbox.commands.run("mkdir -p /home/user/.claude")
+
+        for file_name in ["credentials.json", "settings.json"]:
+            local_file = claude_dir / file_name
+            if local_file.exists():
+                content = local_file.read_text()
+                sandbox.files.write(f"/home/user/.claude/{file_name}", content)
+                logger.debug(f"Synced {file_name} to sandbox")
+
+    async def _setup_github_auth(self, sandbox: Sandbox, gh_token: str) -> None:
+        """Install and configure GitHub CLI in sandbox."""
+        if not gh_token:
+            logger.warning("No GH_TOKEN configured, skipping GitHub auth")
+            return
+
+        # Install gh CLI
+        logger.info("Installing GitHub CLI...")
+        install_result = sandbox.commands.run(
+            "(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) && "
+            "sudo mkdir -p -m 755 /etc/apt/keyrings && "
+            "wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null && "
+            "sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && "
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && '
+            "sudo apt update && sudo apt install gh -y",
+            timeout=120,
+        )
+        if install_result.exit_code != 0:
+            logger.warning(f"Failed to install gh CLI: {install_result.stderr}")
+            return
+
+        # Verify gh is available and auth works
+        result = sandbox.commands.run(
+            f"GH_TOKEN={gh_token} gh auth status",
+            timeout=30,
+        )
+        if result.exit_code == 0:
+            logger.info("GitHub CLI authenticated successfully")
+        else:
+            logger.warning(f"GitHub CLI auth check failed: {result.stderr}")
+
+
+# Singleton instance
+scope_command = ScopeCommand()

--- a/src/aidw/prompts/scope.md
+++ b/src/aidw/prompts/scope.md
@@ -1,0 +1,58 @@
+You are an autonomous scoping agent. Your job is to find unscoped work items and provide technical scoping analysis.
+
+IMPORTANT: This is a READ-ONLY workflow except for adding comments. Do NOT delete, archive, modify status, or make any other changes to Notion items. Only add scoping comments.
+
+## Step 1: Discover Notion Tasks
+
+1. List available databases: `aitk notion dbs`
+2. For each database, list items that appear unscoped (look for status like "New", "Backlog", "Ready for Scoping", or items without estimates/analysis)
+3. Use `aitk notion view <id> --db <db_id>` to get full details
+
+## Step 2: Discover GitHub Repositories
+
+Use the `gh` CLI (already authenticated) to explore the user's repositories:
+1. List user's repos: `gh repo list --limit 100`
+2. List repos for specific orgs the user belongs to: `gh repo list <org> --limit 100`
+3. For relevant repos, examine: `gh repo view <owner/repo>`
+
+Look at:
+- Repository names and descriptions
+- Recent activity
+- Code structure (README, key directories)
+
+## Step 3: Scope Each Task
+
+For each unscoped Notion task:
+1. Analyze what the task requires
+2. Search GitHub repositories thoroughly to find related code. Be persistent - check repo names, descriptions, READMEs, and code structure
+3. ALWAYS identify specific repositories (by full name like owner/repo). Every task should have at least one repo listed:
+   - If it's a coding task: list the repo(s) that need changes
+   - If it's content/docs: list where the content lives (blog repo, docs site, etc.)
+   - If no relevant repo exists: explicitly note "No existing repo found - new repository may need to be created"
+4. Estimate complexity (Low/Medium/High)
+5. Note any risks or unknowns
+
+## Step 4: Post Analysis
+
+For each scoped task, add a comment. Note: Notion comments are plain text only (no markdown rendering), so format cleanly without markdown syntax:
+
+```bash
+aitk notion comment <page_id> "SCOPING ANALYSIS
+
+Summary: <brief summary>
+
+Repositories (list GitHub repos that need changes):
+- owner/repo: <what needs to change>
+
+Complexity: <Low/Medium/High>
+
+Risks:
+- <risk 1>
+
+--
+Scoped by AIDW" --db <db_id>
+```
+
+## Step 5: Summary
+
+Output a summary of what was scoped.


### PR DESCRIPTION
## Summary
- Adds `aidw scope` command for autonomous task scoping
- Discovers unscoped Notion tasks and analyzes relevant GitHub repos
- Posts scoping analysis comments to Notion items

## Changes
- `src/aidw/prompts/scope.md` - Prompt template for scoping workflow
- `src/aidw/commands/scope.py` - Command implementation with sandbox setup
- `src/aidw/cli.py` - CLI entry point for scope command
- `src/aidw/commands/__init__.py` - Export scope_command

## Usage
```bash
aidw scope
aidw scope "Focus on authentication tasks"
```

## Test plan
- [x] Tested scope command discovers Notion databases
- [x] Tested GitHub CLI auth works in sandbox
- [x] Tested scoping comments posted to Notion