### PR TITLE
Add @aidw codereview command

### DIFF
--- a/src/aidw/cli.py
+++ b/src/aidw/cli.py
@@ -237,6 +237,18 @@ def run_iterate(repo: str, pr: int, instruction: str) -> None:
     asyncio.run(iterate_command.execute_manual(repo, pr, instruction))
 
 
+@run.command("codereview")
+@click.option("--repo", required=True, help="Repository (owner/repo)")
+@click.option("--pr", required=True, type=int, help="PR number")
+@click.option("--instruction", default="", help="Review focus or instruction")
+def run_codereview(repo: str, pr: int, instruction: str) -> None:
+    """Review a PR and post a comment with findings."""
+    from aidw.commands import codereview_command
+
+    click.echo(f"Running codereview for {repo}#{pr}")
+    asyncio.run(codereview_command.execute_manual(repo, pr, instruction))
+
+
 @cli.command()
 @click.argument("session_id")
 def status(session_id: str) -> None:

--- a/src/aidw/commands/__init__.py
+++ b/src/aidw/commands/__init__.py
@@ -5,6 +5,7 @@ from aidw.commands.refine import refine_command
 from aidw.commands.build import build_command
 from aidw.commands.oneshot import oneshot_command
 from aidw.commands.iterate import iterate_command
+from aidw.commands.codereview import codereview_command
 from aidw.commands.scope import scope_command
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "build_command",
     "oneshot_command",
     "iterate_command",
+    "codereview_command",
     "scope_command",
 ]

--- a/src/aidw/commands/base.py
+++ b/src/aidw/commands/base.py
@@ -22,6 +22,7 @@ class BaseCommand(ABC):
 
     command_name: str = ""
     prompt_template: str = ""
+    should_push: bool = True
 
     def __init__(self):
         self.db: Database | None = None
@@ -154,7 +155,8 @@ class BaseCommand(ABC):
                         )
 
                         # Push changes
-                        await self.sandbox_manager.push_changes(instance, branch)
+                        if self.should_push:
+                            await self.sandbox_manager.push_changes(instance, branch)
 
                         # Mark complete
                         await self.db.update_session(

--- a/src/aidw/commands/codereview.py
+++ b/src/aidw/commands/codereview.py
@@ -1,0 +1,107 @@
+"""@aidw codereview command - Analyze a PR and post a review comment."""
+
+import logging
+import time
+from typing import Any
+
+from aidw.commands.base import BaseCommand
+from aidw.database import Session
+from aidw.github.context import WorkflowContext
+from aidw.github.progress import ProgressReporter, ProgressStep, ProgressTracker, StepStatus
+from aidw.sandbox import SandboxExecutor
+from aidw.server.webhook import ParsedCommand
+
+logger = logging.getLogger(__name__)
+
+REVIEW_FILE = "AIDW_REVIEW.md"
+
+
+class CodeReviewCommand(BaseCommand):
+    """Analyze a PR and post a structured review comment."""
+
+    command_name = "codereview"
+    prompt_template = "codereview.md"
+    should_push = False
+
+    def get_progress_steps(self) -> list[ProgressStep]:
+        return [
+            ProgressStep("Analyze PR"),
+            ProgressStep("Run code review"),
+            ProgressStep("Post review"),
+        ]
+
+    async def run_workflow(
+        self,
+        session: Session,
+        context: WorkflowContext,
+        executor: SandboxExecutor,
+        progress: ProgressReporter,
+        tracker: ProgressTracker,
+    ) -> dict[str, Any]:
+        """Run the code review workflow."""
+        # Step 1: Analyze PR
+        await self._update_step(tracker, progress, 0, StepStatus.RUNNING)
+        start = time.time()
+
+        prompt = await self._render_prompt(context)
+
+        await self._update_step(
+            tracker, progress, 0, StepStatus.COMPLETED, int(time.time() - start)
+        )
+
+        # Step 2: Run code review via Claude Code
+        await self._update_step(tracker, progress, 1, StepStatus.RUNNING)
+        start = time.time()
+
+        result = await executor.run_claude(prompt)
+
+        if not result.success:
+            raise RuntimeError(f"Claude Code failed: {result.error}")
+
+        await self._update_step(
+            tracker, progress, 1, StepStatus.COMPLETED, int(time.time() - start)
+        )
+
+        # Step 3: Post review comment
+        await self._update_step(tracker, progress, 2, StepStatus.RUNNING)
+        start = time.time()
+
+        # Read the review file from the sandbox
+        review_content = await self.sandbox_manager.read_file(
+            executor.instance, f"/home/user/repo/{REVIEW_FILE}"
+        )
+
+        if not review_content:
+            raise RuntimeError(f"Review file {REVIEW_FILE} not found in sandbox")
+
+        # Post as a comment on the PR
+        comment_body = f"## AIDW Code Review\n\n{review_content}"
+        await self.github.create_comment(
+            session.repo,
+            session.pr_number,
+            comment_body,
+        )
+
+        await self._update_step(
+            tracker, progress, 2, StepStatus.COMPLETED, int(time.time() - start)
+        )
+
+        return {}
+
+    async def execute_manual(self, repo: str, pr: int, instruction: str = "") -> None:
+        """Execute codereview command manually."""
+        cmd = ParsedCommand(
+            command=self.command_name,
+            instruction=instruction,
+            author="manual",
+            body=f"@aidw {self.command_name} {instruction}".strip(),
+            repo=repo,
+            issue_number=pr,
+            pr_number=pr,
+            comment_id=0,
+        )
+        await self.execute(cmd)
+
+
+# Singleton instance
+codereview_command = CodeReviewCommand()

--- a/src/aidw/prompts/codereview.md
+++ b/src/aidw/prompts/codereview.md
@@ -1,0 +1,50 @@
+{% include 'context.md' %}
+
+---
+
+You are performing a **code review** of this pull request. This is a read-only review — do NOT modify any source code, tests, or documentation.
+
+Analyze the code changes on the current branch compared to the base branch. Run `git diff main...HEAD` (or the appropriate base branch) to see all changes.
+
+Consider:
+- **Code quality**: Readability, maintainability, naming, structure
+- **Bugs**: Logic errors, off-by-one, null/undefined handling, race conditions
+- **Security**: Injection, auth issues, secrets exposure, input validation
+- **Edge cases**: Missing error handling, boundary conditions, empty/null inputs
+- **Patterns**: Consistency with existing codebase conventions and architecture
+- **Performance**: Unnecessary allocations, N+1 queries, missing indexes
+
+{% if trigger.instruction %}
+**Reviewer's focus**: {{ trigger.instruction }}
+{% endif %}
+
+Write your complete review to a file called `AIDW_REVIEW.md` in the repository root. Use this structure:
+
+```markdown
+### Summary
+One paragraph summarizing what this PR does and your overall assessment.
+
+### Strengths
+- What's done well
+
+### Issues
+
+#### Critical
+- Bugs, security issues, or correctness problems that must be fixed
+
+#### Important
+- Significant concerns that should be addressed
+
+#### Minor
+- Style, naming, or small improvements
+
+### Questions
+- Anything unclear that the author should clarify
+
+### Suggestions
+- Optional improvements or alternative approaches
+```
+
+Reference specific files and line numbers (e.g., `src/foo.py:42`). If a category has no items, omit it.
+
+Do NOT modify any files other than `AIDW_REVIEW.md`. Do NOT commit changes.

--- a/src/aidw/server/app.py
+++ b/src/aidw/server/app.py
@@ -67,6 +67,7 @@ async def process_command(cmd: ParsedCommand) -> None:
     """Process a parsed command in the background."""
     from aidw.commands import (
         build_command,
+        codereview_command,
         iterate_command,
         oneshot_command,
         plan_command,
@@ -86,6 +87,8 @@ async def process_command(cmd: ParsedCommand) -> None:
             await oneshot_command.execute(cmd)
         elif cmd.command == "iterate":
             await iterate_command.execute(cmd)
+        elif cmd.command == "codereview":
+            await codereview_command.execute(cmd)
         else:
             logger.error(f"Unknown command: {cmd.command}")
     except Exception as e:

--- a/src/aidw/server/webhook.py
+++ b/src/aidw/server/webhook.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 # Command pattern: @aidw <command> [instruction]
 COMMAND_PATTERN = re.compile(
-    r"@(\w+)\s+(plan|refine|build|oneshot|iterate)(?:\s+(.*))?",
+    r"@(\w+)\s+(plan|refine|build|oneshot|iterate|codereview)(?:\s+(.*))?",
     re.IGNORECASE | re.DOTALL,
 )
 
@@ -156,7 +156,7 @@ def validate_command_context(cmd: ParsedCommand) -> str | None:
             return f"`@aidw {cmd.command}` must be run from an issue, not a PR"
 
     # refine, build, iterate require a PR
-    if cmd.command in ("refine", "build", "iterate"):
+    if cmd.command in ("refine", "build", "iterate", "codereview"):
         if cmd.pr_number is None:
             return f"`@aidw {cmd.command}` must be run from a PR"
 


### PR DESCRIPTION
## Summary
- Adds `@aidw codereview` command that performs read-only PR analysis in an E2B sandbox and posts structured review comments
- Introduces `should_push` flag on `BaseCommand` so codereview skips the push step
- Registers the command across webhook, server dispatch, CLI, and exports
- Updates README with codereview docs and general polish

## Test plan
- [ ] `pip install -e .` from repo root
- [ ] `aidw run codereview --repo Mandalorian007/aitk --pr <number>` posts a review comment
- [ ] `@aidw codereview` on a PR via webhook triggers the workflow
- [ ] Existing commands (plan, build, refine, iterate, oneshot) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)