### PR TITLE
Fix E2B SDK v2 CommandExitException handling

### DIFF
--- a/src/aidw/sandbox/executor.py
+++ b/src/aidw/sandbox/executor.py
@@ -242,8 +242,11 @@ class SandboxExecutor:
     async def file_exists(self, path: str) -> bool:
         """Check if a file exists in the repo."""
         full_path = f"{self.instance.repo_path}/{path}"
-        result = self.instance.sandbox.commands.run(f"test -f {full_path} && echo 'yes'")
-        return result.stdout.strip() == "yes"
+        try:
+            result = self.instance.sandbox.commands.run(f"test -f {full_path} && echo 'yes'")
+            return result.stdout.strip() == "yes"
+        except Exception:
+            return False
 
     async def read_repo_file(self, path: str) -> str | None:
         """Read a file from the repo."""

--- a/src/aidw/sandbox/manager.py
+++ b/src/aidw/sandbox/manager.py
@@ -91,8 +91,11 @@ class SandboxManager:
         logger.info("Installing tools in sandbox...")
 
         # Check if uv is available (preferred), otherwise fall back to pip
-        uv_check = instance.sandbox.commands.run("which uv", timeout=10)
-        use_uv = uv_check.exit_code == 0
+        try:
+            instance.sandbox.commands.run("which uv", timeout=10)
+            use_uv = True
+        except Exception:
+            use_uv = False
 
         if use_uv:
             # Use uv tool install for isolated installation


### PR DESCRIPTION
## Summary
- E2B SDK v2 raises `CommandExitException` on non-zero exit codes instead of returning a result object
- Wraps `which uv` check in try/except so sandbox init falls back to pip gracefully
- Wraps `file_exists` check in try/except so it returns `False` instead of crashing

## Test plan
- [ ] `aidw run codereview --repo Mandalorian007/aitk --pr 4` completes without sandbox init error

🤖 Generated with [Claude Code](https://claude.com/claude-code)