### PR TITLE
Add webhook CLI commands and server.domain config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,28 @@ aidw server           # Start webhook server
 aidw server --dev     # With auto-reload
 ```
 
-Expose with [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) or ngrok, then configure your GitHub repo's webhook to point to `https://your-url/webhook`.
+### Webhook Management
+
+Manage GitHub webhooks directly from the CLI:
+
+```bash
+aidw webhook add --repo owner/repo       # Create webhook on a repo
+aidw webhook status --repo owner/repo    # Show config + recent deliveries
+aidw webhook remove --repo owner/repo    # Remove webhook from a repo
+```
+
+The webhook URL is built from `server.domain` in `~/.config/aidw/config.yml`. Set it during `aidw config` or manually:
+
+```yaml
+server:
+  domain: https://your-server.example.com
+  port: 8787
+  workers: 3
+```
+
+If no domain is configured, it falls back to `http://localhost:{port}/webhook`.
+
+You can also expose the server with [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) or ngrok.
 
 ### Manual Triggers
 

--- a/src/aidw/env.py
+++ b/src/aidw/env.py
@@ -28,6 +28,7 @@ class ServerConfig(BaseSettings):
     port: int = Field(default=8787, description="Server port")
     workers: int = Field(default=3, description="Number of workers")
     host: str = Field(default="0.0.0.0", description="Server host")
+    domain: str | None = Field(default=None, description="Public domain for webhook URL")
 
 
 class GitHubConfig(BaseSettings):
@@ -61,6 +62,13 @@ class Settings(BaseSettings):
     server: ServerConfig = Field(default_factory=ServerConfig)
     github: GitHubConfig = Field(default_factory=GitHubConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
+
+    @property
+    def webhook_url(self) -> str:
+        """Construct the webhook URL from domain or localhost fallback."""
+        if self.server.domain:
+            return f"{self.server.domain.rstrip('/')}/webhook"
+        return f"http://localhost:{self.server.port}/webhook"
 
 
 def load_config_file() -> dict:
@@ -117,6 +125,7 @@ def create_default_config() -> None:
         "server": {
             "port": 8787,
             "workers": 3,
+            "domain": None,
         },
         "github": {
             "bot_name": "aidw",

--- a/src/aidw/github/__init__.py
+++ b/src/aidw/github/__init__.py
@@ -1,6 +1,6 @@
 """AIDW GitHub - GitHub API client and context assembly."""
 
-from aidw.github.client import GitHubClient
+from aidw.github.client import GitHubClient, Webhook, WebhookDelivery
 from aidw.github.context import ContextBuilder
 
-__all__ = ["GitHubClient", "ContextBuilder"]
+__all__ = ["GitHubClient", "ContextBuilder", "Webhook", "WebhookDelivery"]


### PR DESCRIPTION
## Summary
- Adds `server.domain` config field so the CLI can construct webhook URLs automatically
- Adds `aidw webhook add/remove/status` commands to manage GitHub webhooks from the CLI
- Adds domain prompt to the `aidw config` interactive flow
- Updates README with webhook management documentation

## Test plan
- [ ] `aidw config` — verify domain prompt appears between credentials and allowed-users
- [ ] `aidw webhook add --repo Mandalorian007/aidw` — verify webhook creation
- [ ] `aidw webhook status --repo Mandalorian007/aidw` — verify config + delivery display
- [ ] `aidw webhook remove --repo Mandalorian007/aidw` — verify webhook removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)