### PR TITLE
Improve PR output for human reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,52 @@ Install slash commands to `~/.claude/commands/aidw/` and verify dependencies.
 
 Remove slash commands and clean up worktrees.
 
+## What to Expect
+
+### Draft PRs
+
+When `aidw one-shot` finishes, you get a draft PR with a structured body:
+
+```
+## Summary
+Add rate limiting to API endpoints using a token bucket algorithm
+to prevent abuse and ensure fair usage across tenants.
+
+## Changes
+- Add rate limiter middleware with per-tenant token bucket
+- Wire middleware into API router for all authenticated endpoints
+- Add configuration for rate limits in settings
+
+## Testing
+- Unit tests for token bucket logic pass
+- Integration tests verify rate limiting triggers at threshold
+- Existing API tests unaffected
+```
+
+### Iteration Comments
+
+When `aidw iterate` finishes, it posts a comment on the PR summarizing what changed:
+
+```
+## Iteration Summary
+Address reviewer feedback on error handling and test coverage.
+
+### Feedback Addressed
+- Reviewer: return 429 with Retry-After header instead of generic 400
+- Reviewer: add test for concurrent request handling
+
+### Changes Made
+- Updated rate limiter to return 429 with Retry-After header
+- Added concurrent request test using threading
+
+### Testing
+- All existing and new tests pass
+```
+
+### Timing
+
+Runs typically take 5-15 minutes depending on task complexity and codebase size.
+
 ## Slash Commands
 
 After `aidw setup`, these commands are available inside any Claude Code session:

--- a/src/aidw/cli.py
+++ b/src/aidw/cli.py
@@ -96,6 +96,11 @@ def one_shot(description: str) -> None:
     click.echo(f"Generating PR for: {description}")
     click.echo(f"Worktree: {worktree_name}")
     click.echo()
+    click.secho(
+        "Claude is designing, implementing, and testing your changes. "
+        "This typically takes 5-15 minutes.",
+        fg="cyan",
+    )
 
     try:
         result_text = run_claude("/aidw:one-shot-pr", description, worktree_name)
@@ -111,6 +116,7 @@ def one_shot(description: str) -> None:
     pr_url = extract_pr_url(result_text)
     if pr_url:
         click.echo()
+        click.secho("Draft PR created:", fg="green")
         click.secho(pr_url, fg="green", bold=True)
     else:
         click.echo()
@@ -156,6 +162,11 @@ def iterate(pr: str, feedback: str) -> None:
         click.echo(f"Feedback: {feedback}")
     click.echo(f"Worktree: {worktree_name}")
     click.echo()
+    click.secho(
+        "Claude is reviewing feedback and updating the PR. "
+        "This typically takes 5-15 minutes.",
+        fg="cyan",
+    )
 
     arguments = f"--pr {pr_number} --branch {branch}"
     if feedback:
@@ -175,6 +186,7 @@ def iterate(pr: str, feedback: str) -> None:
     pr_url = extract_pr_url(result_text)
     if pr_url:
         click.echo()
+        click.secho("PR updated:", fg="green")
         click.secho(pr_url, fg="green", bold=True)
     else:
         click.echo()

--- a/src/aidw/prompts/iterate.md
+++ b/src/aidw/prompts/iterate.md
@@ -136,4 +136,21 @@ Launch another round if the previous round made fixes (fixes can introduce new i
 1. **Clean up** — remove `/tmp/$BRANCH-plan.md`
 2. **Commit** — clear commit message describing what feedback was addressed. Atomic commits where appropriate.
 3. **Push** — `git push origin HEAD`
-4. **Output the PR URL** — print the PR URL as the very last line of your response. This is critical — the calling tool parses it from your output.
+4. **Post an iteration summary** as a comment on the PR so reviewers can see what changed:
+   ```
+   gh pr comment <number> --body "$(cat <<'EOF'
+   ## Iteration Summary
+   <1-2 sentences: what this iteration addresses>
+
+   ### Feedback Addressed
+   <bullet list of review feedback and user instructions that were addressed>
+
+   ### Changes Made
+   <bullet list of key changes>
+
+   ### Testing
+   <what was tested and verified>
+   EOF
+   )"
+   ```
+5. **Output the PR URL** — print the PR URL as the very last line of your response. Use `gh pr view <number> --json url -q .url` to get the URL. This is critical — the calling tool parses it from your output.

--- a/src/aidw/prompts/one-shot-pr.md
+++ b/src/aidw/prompts/one-shot-pr.md
@@ -125,8 +125,19 @@ Launch another round if the previous round made fixes (fixes can introduce new i
 1. **Clean up** — remove `/tmp/$BRANCH-plan.md`
 2. **Commit** — clear, descriptive commit messages. Atomic commits where appropriate.
 3. **Push** — `git push origin HEAD`
-4. **Create a draft PR:**
+4. **Create a draft PR** with a structured body that helps human reviewers:
    ```
-   gh pr create --draft --title "<concise title>" --body "<description of changes>"
+   gh pr create --draft --title "<concise, descriptive title>" --body "$(cat <<'EOF'
+   ## Summary
+   <1-3 sentences: what this PR does and why>
+
+   ## Changes
+   <bullet list of key changes, grouped by area — focus on what matters to a reviewer, not every file touched>
+
+   ## Testing
+   <what was tested: commands run, checks passed, edge cases verified>
+   EOF
+   )"
    ```
+   **Title guidance:** Use a clear action phrase (e.g., "Add rate limiting to API endpoints", "Fix session timeout handling"). Avoid vague titles like "Update code" or "Various improvements".
 5. **Output the PR URL** — print the PR URL as the very last line of your response. This is critical — the calling tool parses it from your output.


### PR DESCRIPTION
## Summary
PRs created by AIDW were optimized for the agent workflow but lacked structure for human reviewers. This adds structured templates so PRs and iteration comments are clear and useful for the people who review them.

## Changes
- **one-shot-pr.md**: Replace generic `--body "<description>"` with a structured PR body template (Summary, Changes, Testing sections) and title guidance
- **iterate.md**: Add `gh pr comment` step so each iteration posts a summary of what feedback was addressed and what changed
- **cli.py**: Add duration hints before long-running operations and labeled success messages ("Draft PR created:", "PR updated:")
- **README.md**: Add "What to Expect" section with example PR body and iteration comment output

## Testing
- Python syntax verified via `ast.parse`
- Markdown formatting reviewed for correctness
- Prompt template placeholders ($ARGUMENTS, $BRANCH, `<number>`) verified consistent with existing usage